### PR TITLE
Fetch full history

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
     - name: Checkout repository
       with:
         submodules: true
+        fetch-depth: 0
       uses: actions/checkout@v4
 
     - name: Install dependencies


### PR DESCRIPTION
Change the fetch depth to 0 to have the full history of the submodules to properly compute ksu next version 